### PR TITLE
[fix] fix precision of p-value and confidence for Welch's test

### DIFF
--- a/hypothesis/abstact.js
+++ b/hypothesis/abstact.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const cephes = require('cephes');
+
 function AbstactStudentT(options) {
   this._options = options;
 }
@@ -13,13 +15,16 @@ AbstactStudentT.prototype.testValue = function () {
 AbstactStudentT.prototype.pValue = function () {
   const t = this.testValue();
 
-  switch (this._options.alternative) {
+  const alternative = this._one ? this._options.alternative : -this._options.alternative;
+  const x = this._df / (this._df + t * t);
+  const cdf = cephes.incbet(0.5 * this._df, 0.5, x);
+  switch (alternative) {
   case 1: // mu > mu[0]
-    return 1 - this._dist.cdf(t);
+    return 0.5 * cdf;
   case -1: // mu < mu[0]
-    return this._dist.cdf(t);
+    return 1 - 0.5 * cdf;
   case 0: // mu != mu[0]
-    return 2 * (1 - this._dist.cdf(Math.abs(t)));
+    return cdf;
   }
 };
 
@@ -27,13 +32,13 @@ AbstactStudentT.prototype.confidence = function () {
   let pm;
   switch (this._options.alternative) {
   case 1: // mu > mu[0]
-    pm = Math.abs(this._dist.inv(this._options.alpha)) * this._se;
+    pm = Math.abs(inverseStudent(this._df, this._options.alpha)) * this._se;
     return [this._mean - pm, Infinity];
   case -1: // mu < mu[0]
-    pm = Math.abs(this._dist.inv(this._options.alpha)) * this._se;
+    pm = Math.abs(inverseStudent(this._df, this._options.alpha)) * this._se;
     return [-Infinity, this._mean + pm];
   case 0: // mu != mu[0]
-    pm = Math.abs(this._dist.inv(this._options.alpha / 2)) * this._se;
+    pm = Math.abs(inverseStudent(this._df, this._options.alpha / 2)) * this._se;
     return [this._mean - pm, this._mean + pm];
   }
 };
@@ -44,4 +49,28 @@ AbstactStudentT.prototype.valid = function () {
 
 AbstactStudentT.prototype.freedom = function () {
   return this._df;
+}
+
+function inverseStudent(k, p) {
+  if (p > 0.25 && p < 0.75) {
+    if (p === 0.5) {
+      return 0;
+    }
+    let z = 1 - 2 * p;
+    z = cephes.incbi(0.5, 0.5 * k, Math.abs(z));
+    let t = Math.sqrt(k * z / (1 - z));
+    if (p < 0.5) {
+      t = -t;
+    }
+    return t;
+  } else {
+    let rflg = -1;
+    if (p >= 0.5) {
+      p = 1 - p;
+      rflg = 1;
+    }
+    const z = cephes.incbi(0.5 * k, 0.5, 2 * p);
+    const t = Math.sqrt(k / z - k);
+    return rflg * t;
+  }
 }

--- a/hypothesis/one-data-set.js
+++ b/hypothesis/one-data-set.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const Distribution = require('distributions').Studentt;
-
 const util = require('util');
 const AbstactStudentT = require('./abstact.js');
 
 function StudentT(data, options) {
   AbstactStudentT.call(this, options);
 
+  this._one = true;
   this._df = data.size - 1;
-  this._dist = new Distribution(this._df);
 
   this._se = Math.sqrt(data.variance / data.size);
   this._mean = data.mean;

--- a/hypothesis/two-data-set.js
+++ b/hypothesis/two-data-set.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const Distribution = require('distributions').Studentt;
-
 const util = require('util');
 const AbstactStudentT = require('./abstact.js');
 
 function StudentT(left, right, options) {
   AbstactStudentT.call(this, options);
 
+  this._one = false;
   this._df = left.size + right.size - 2;
-  this._dist = new Distribution(this._df);
 
   const commonVariance = ((left.size - 1) * left.variance +
                           (right.size - 1) * right.variance

--- a/hypothesis/welch.js
+++ b/hypothesis/welch.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const Distribution = require('distributions').Studentt;
-
 const util = require('util');
 const AbstactStudentT = require('./abstact.js');
 
 function StudentT(left, right, options) {
   AbstactStudentT.call(this, options);
 
+  this._one = false;
   const leftSE = left.variance / left.size;
   const rightSE = right.variance / right.size;
   const commonVariance = leftSE + rightSE;
@@ -16,7 +15,6 @@ function StudentT(left, right, options) {
     Math.pow(leftSE, 2) / (left.size - 1) +
     Math.pow(rightSE, 2) / (right.size - 1)
   );
-  this._dist = new Distribution(this._df);
 
   this._se = Math.sqrt(commonVariance);
   this._mean = left.mean - right.mean;

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "student t"
   ],
   "dependencies": {
-    "summary": "0.3.x",
-    "distributions": "^2.0.0"
+    "cephes": "^1.2.0",
+    "summary": "0.3.x"
   },
   "devDependencies": {
     "eslint": "^3.2.2",

--- a/test/simple/welch.js
+++ b/test/simple/welch.js
@@ -18,19 +18,19 @@ test('testing not equal alternative', function (t) {
     valid: true,
     freedom: 7.769053117782910966582,
 
-    pValue: 0.23056556843894693,
+    pValue: 0.22661539838413605,
     testValue: -1.313064328597225660644,
 
     confidence: [
-      -1.80084417807539,
-      1.80084417807539
+      -1.7653291692417925,
+      1.7653291692417925
     ]
   });
 
   t.end();
 });
 
-test('testing not equal alternative', function (t) {
+test('testing not equal alternative with summary', function (t) {
   const res = ttest(summary([1, 2, 2, 2, 4]), summary([0, 3, 3, 3, 2]), {
     mu: 1,
     varEqual: false,
@@ -42,12 +42,12 @@ test('testing not equal alternative', function (t) {
     valid: true,
     freedom: 7.769053117782910966582,
 
-    pValue: 0.23056556843894693,
+    pValue: 0.22661539838413605,
     testValue: -1.313064328597225660644,
 
     confidence: [
-      -1.80084417807539,
-      1.80084417807539
+      -1.7653291692417925,
+      1.7653291692417925
     ]
   });
 
@@ -66,12 +66,12 @@ test('testing less alternative', function (t) {
     valid: true,
     freedom: 7.769053117782910966582,
 
-    pValue: 0.11528278421947352,
+    pValue: 0.11330769919206803,
     testValue: -1.313064328597225660644,
 
     confidence: [
       -Infinity,
-      1.4428680787589634
+      1.4216665293566955
     ]
   });
 
@@ -90,11 +90,11 @@ test('testing greater alternative', function (t) {
     valid: true,
     freedom: 7.769053117782910966582,
 
-    pValue: 0.8847172157805265,
+    pValue: 0.8866923008079319,
     testValue: -1.313064328597225660644,
 
     confidence: [
-      -1.4428680787589634,
+      -1.4216665293566955,
       Infinity
     ]
   });


### PR DESCRIPTION
cephes' stdtr and stdtri functions both take an integer argument for the
degrees of freedom. This is problematic for Welch's t-test because the
computed dfs are not integers.
This change makes direct use of the incomplete beta integral to do the
calculations, like Python's SciPy implementation does.
After this change, the p-value and confidence interval are the same as
what R and SciPy return.

Fixes: https://github.com/AndreasMadsen/ttest/issues/6
Refs: https://github.com/scipy/scipy/blob/09feb51dede02257cc0cdee2b39b0786fd1c0ab5/scipy/stats/mstats_basic.py#L1064